### PR TITLE
Fix macOS and windows builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,12 +86,18 @@ jobs:
         env:
           nuitka_cache: ${{ github.workspace }}/.nuitka
       - name: Upload executable
+        if: matrix.os != 'windows-latest'
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.os }}
-          path: |
-            dist/codexctl.bin
-            dist/codexctl.exe
+          path: dist/codexctl.bin
+          if-no-files-found: error
+      - name: Upload executable
+        if: matrix.os == 'windows-latest'
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.os }}
+          path: dist/codexctl.exe
           if-no-files-found: error
   device:
     name: Build for remarkable

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -154,7 +154,7 @@ jobs:
       matrix:
         fw_version: ['2.15.1', '3.3.2', '3.9.3']
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           path: artifacts
           name: remarkable

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
           mv .ccache "$nuitka_cache/ccache"
         env:
           nuitka_cache: ${{ github.workspace }}/.nuitka
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -69,7 +69,7 @@ jobs:
         env:
           nuitka_cache: ${{ github.workspace }}/.nuitka
       - name: Upload Compilation Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if:  runner.debug == '1'
         with:
           name: ${{ matrix.os }}-compilation-report
@@ -87,14 +87,14 @@ jobs:
           nuitka_cache: ${{ github.workspace }}/.nuitka
       - name: Upload executable
         if: matrix.os != 'windows-latest'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.os }}
           path: dist/codexctl.bin
           if-no-files-found: error
       - name: Upload executable
         if: matrix.os == 'windows-latest'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.os }}
           path: dist/codexctl.exe
@@ -134,17 +134,17 @@ jobs:
             source /opt/lib/nuitka/bin/activate
             ./github-make-executable.sh
       - name: Upload Compilation Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if:  runner.debug == '1'
         with:
           name: ${{ matrix.os }}-compilation-report
           path: compilation-report.xml
           if-no-files-found: warn
       - name: Upload executable
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: remarkable
-          path: dist
+          path: dist/codexctl.bin
           if-no-files-found: error
   test_device:
     name: Test for reMarkable ${{ matrix.fw_version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,7 +89,9 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.os }}
-          path: dist
+          path: |
+            dist/codexctl.bin
+            dist/codexctl.exe
           if-no-files-found: error
   device:
     name: Build for remarkable

--- a/Makefile
+++ b/Makefile
@@ -63,12 +63,6 @@ executable: $(VENV_BIN_ACTIVATE)
 	. $(VENV_BIN_ACTIVATE); \
 	NUITKA_CACHE_DIR="$(realpath .)/.nuitka" \
 	python -m nuitka \
-	    --enable-plugin=pylint-warnings \
-	    --enable-plugin=upx \
-	     --include-package=google \
-	    --warn-implicit-exceptions \
-	    --onefile \
-	    --lto=yes \
 	    --assume-yes-for-downloads \
 	    --remove-output \
 	    --output-dir=dist \

--- a/Makefile
+++ b/Makefile
@@ -35,18 +35,24 @@ test: $(VENV_BIN_ACTIVATE) .venv/${FW_VERSION}_reMarkable2-${FW_DATA}.signed
 	fi
 	mkdir -p .venv/mnt
 	. $(VENV_BIN_ACTIVATE); \
-	python -m codexctl mount --out .venv/mnt ".venv/${FW_VERSION}_reMarkable2-${FW_DATA}.signed"
-	mountpoint .venv/mnt
-	umount -ql .venv/mnt
-	. $(VENV_BIN_ACTIVATE); \
-	python -m codexctl extract --out ".venv/${FW_VERSION}_reMarkable2-${FW_DATA}.img" ".venv/${FW_VERSION}_reMarkable2-${FW_DATA}.signed"
-	echo "${IMG_SHA}  .venv/${FW_VERSION}_reMarkable2-${FW_DATA}.img" | sha256sum --check
-	rm -f ".venv/${FW_VERSION}_reMarkable2-${FW_DATA}.img"
+	if [[ "linux" == "$$(python -c 'import sys;print(sys.platform)')" ]]; then \
+	  python -m codexctl mount --out .venv/mnt ".venv/${FW_VERSION}_reMarkable2-${FW_DATA}.signed"; \
+	  mountpoint .venv/mnt; \
+	  umount -ql .venv/mnt; \
+	  python -m codexctl extract --out ".venv/${FW_VERSION}_reMarkable2-${FW_DATA}.img" ".venv/${FW_VERSION}_reMarkable2-${FW_DATA}.signed"; \
+	  echo "${IMG_SHA}  .venv/${FW_VERSION}_reMarkable2-${FW_DATA}.img" | sha256sum --check; \
+	  rm -f ".venv/${FW_VERSION}_reMarkable2-${FW_DATA}.img"; \
+	fi
 
 test-executable: .venv/${FW_VERSION}_reMarkable2-${FW_DATA}.signed
-	dist/codexctl.* extract --out ".venv/${FW_VERSION}_reMarkable2-${FW_DATA}.img" ".venv/${FW_VERSION}_reMarkable2-${FW_DATA}.signed"
-	echo "${IMG_SHA}  .venv/${FW_VERSION}_reMarkable2-${FW_DATA}.img" | sha256sum --check
-	rm -f ".venv/${FW_VERSION}_reMarkable2-${FW_DATA}.img"
+	. $(VENV_BIN_ACTIVATE); \
+	if [[ "linux" == "$$(python -c 'import sys;print(sys.platform)')" ]]; then \
+	  dist/codexctl.* extract --out ".venv/${FW_VERSION}_reMarkable2-${FW_DATA}.img" ".venv/${FW_VERSION}_reMarkable2-${FW_DATA}.signed"; \
+	  echo "${IMG_SHA}  .venv/${FW_VERSION}_reMarkable2-${FW_DATA}.img" | sha256sum --check; \
+	  rm -f ".venv/${FW_VERSION}_reMarkable2-${FW_DATA}.img"; \
+	else \
+	  dist/codexctl.* list; \
+	fi
 
 clean:
 	@echo "[info] Cleaning"

--- a/codexctl.py
+++ b/codexctl.py
@@ -1,3 +1,11 @@
+# nuitka-project: --enable-plugin=pylint-warnings
+# nuitka-project: --enable-plugin=upx
+# nuitka-project: --warn-implicit-exceptions
+# nuitka-project: --onefile
+# nuitka-project: --lto=yes
+# nuitka-project-if: {OS} in ("Linux"):
+#    nuitka-project: --include-package=google
+
 from codexctl import main
 
 if __name__ == "__main__":

--- a/codexctl.py
+++ b/codexctl.py
@@ -5,6 +5,7 @@
 # nuitka-project: --lto=yes
 # nuitka-project-if: {OS} in ("Linux"):
 #    nuitka-project: --include-package=google
+#    nuitka-project: --noinclude-unittest-mode=allow
 
 from codexctl import main
 

--- a/github-make-executable.sh
+++ b/github-make-executable.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set +e
 
-make executable test-executable 2>&1 \
+make executable 2>&1 \
 | while read -r line; do
   IFS=$'\n' read -r -a lines <<< "$line"
   if [[ "$line" == 'Nuitka'*':ERROR:'* ]] || [[ "$line" == 'FATAL:'* ]] || [[ "$line" == 'make: *** ['*'] Error'* ]] ; then
@@ -12,6 +12,9 @@ make executable test-executable 2>&1 \
     echo "$line"
   else
     printf '::debug::%s\n' "${lines[@]}"
-    echo "::debug::$line"
   fi
 done
+if ! make test-executable; then
+  printf '::error file=codexctl.bin,title=Test Error::Sanity test failed\n'
+  exit 1
+fi

--- a/github-make-executable.sh
+++ b/github-make-executable.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
+set +e
 
 make executable test-executable 2>&1 \
 | while read -r line; do
   IFS=$'\n' read -r -a lines <<< "$line"
-  if [[ "$line" == 'Nuitka'*':ERROR:'* ]]; then
+  if [[ "$line" == 'Nuitka'*':ERROR:'* ]] || [[ "$line" == 'FATAL:'* ]] || [[ "$line" == 'make: *** ['*'] Error'* ]] ; then
     printf '::error file=codexctl.py,title=Nuitka Error::%s\n' "${lines[@]}"
   elif [[ "$line" == 'Nuitka'*':WARNING:'* ]]; then
     printf '::warning file=codexctl.py,title=Nuitka Warning::%s\n' "${lines[@]}"


### PR DESCRIPTION
- Error if the binary is missing
- Expose more errors without debug logging
- Moved most of the nuitka options into the codexctl.py file