### PR TITLE
fix instructions for setting device type

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ codexctl install latest
 ```
 - Downloading rmpp version 3.15.4.2 to a folder named `out` and then installing it
 ```
-codexctl download 3.15.4.2 -hw rmpp -o out
+codexctl download 3.15.4.2 -hd rmpp -o out
 codexctl install ./out/remarkable-ct-prototype-image-3.15.4.2-ferrari-public.swu
 ```
 - Backing up all documents to the cwd


### PR DESCRIPTION
previously, it was `-hw`, but when actually using codexctl, it took `-hd`, at least in the windows binary release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated README with a minor correction to the command-line usage example for firmware download
	- Changed command-line flag from `-hw` to `-hd` in the download instruction

<!-- end of auto-generated comment: release notes by coderabbit.ai -->