### PR TITLE
Fix getting machine name when running on device

### DIFF
--- a/codexctl/device.py
+++ b/codexctl/device.py
@@ -49,7 +49,7 @@ class DeviceManager:
         else:
             try:
                 with open("/sys/devices/soc0/machine") as file:
-                    machine_contents = file.read().decode("utf-8").strip("\n")
+                    machine_contents = file.read().strip("\n")
             except FileNotFoundError:
                 machine_contents = "tests"
 


### PR DESCRIPTION
`file.read()` is already a string and not a bytes object, so you can't decode it.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined device initialization by simplifying the configuration file reading process. The update maintains existing error handling and fallback behavior while improving internal efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->