### PR TITLE
 Add incremental document backup 

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ codexctl install ./out/remarkable-ct-prototype-image-3.15.4.2-ferrari-public.swu
 ```
 codexctl backup 
 ```
+- Backing up modified/newer documents only, overwrites out-of-date files on disk
+```
+codexctl backup --incremental
+```
 - Backing up only documents in a folder named "FM" to cwd, without overwriting any current files
 ```
 codexctl backup -l root -r FM --no-recursion --no-overwrite
@@ -71,6 +75,3 @@ codexctl restore
 codexctl download 3.8.0.1944 --hardware rm2
 codexctl cat 3.8.0.1944_reMarkable2-7eGpAv7sYB.signed /etc/version
 ```
-
-
-

--- a/codexctl/__init__.py
+++ b/codexctl/__init__.py
@@ -161,6 +161,7 @@ class Manager:
                     remoteFolder=args["remote"],
                     recursive=not args["no_recursion"],
                     overwrite=not args["no_overwrite"],
+                    incremental=args["incremental"],
                 )
             else:
                 rmWeb.upload(input_paths=args["paths"], remoteFolder=args["remote"])
@@ -387,6 +388,12 @@ def main() -> None:
     )
     backup.add_argument(
         "-no-ow", "--no-overwrite", help="Disables overwrite", action="store_true"
+    )
+    backup.add_argument(
+        "-i",
+        "--incremental",
+        help="Overwrite out-of-date files only",
+        action="store_true",
     )
 
     ### Cat subcommand

--- a/codexctl/sync.py
+++ b/codexctl/sync.py
@@ -13,8 +13,9 @@ class RmWebInterfaceAPI:  # TODO: Add docstrings
             self.logger = logging
 
         self.BASE = BASE
-        self.NAME_ATTRIBUTE = "VissibleName"
         self.ID_ATTRIBUTE = "ID"
+        self.NAME_ATTRIBUTE = "VissibleName"
+        self.MTIME_ATTRIBUTE = "ModifiedClient"
 
         self.logger.debug(f"Base is: {BASE}")
 
@@ -112,7 +113,7 @@ class RmWebInterfaceAPI:  # TODO: Add docstrings
 
         return [item for item in data if "fileType" in item]
 
-    def download(self, document, location="", overwrite=False):
+    def download(self, document, location="", overwrite=False, incremental=False):
         filename = document[self.NAME_ATTRIBUTE]
         if "/" in filename:
             filename = filename.replace("/", "_")
@@ -125,9 +126,14 @@ class RmWebInterfaceAPI:  # TODO: Add docstrings
 
         try:
             fileLocation = f"{location}/{filename}.pdf"
+            isFile = os.path.isfile(fileLocation)
 
-            if os.path.isfile(fileLocation) and overwrite is False:
+            if isFile and not overwrite:
                 self.logger.debug("Not overwriting file")
+                return True
+
+            if isFile and incremental and not self.__is_newer(document, fileLocation):
+                self.logger.debug("Local file already exists and is newer, skipping")
                 return True
 
             binaryData = self.__POST(
@@ -146,6 +152,16 @@ class RmWebInterfaceAPI:  # TODO: Add docstrings
         except Exception as error:
             print(f"Error trying to download {filename}: {error}")
             return False
+
+    def __is_newer(self, document, fileLocation):
+        import time
+
+        remote_ts = document[self.MTIME_ATTRIBUTE]
+
+        local_mtime = os.path.getmtime(fileLocation)
+        local_ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(local_mtime))
+
+        return remote_ts > local_ts
 
     def upload(self, input_paths, remoteFolder):
         folderId = ""
@@ -196,7 +212,14 @@ class RmWebInterfaceAPI:  # TODO: Add docstrings
 
         print(f"Done! {len(documents)-len(errors)} files were uploaded.")
 
-    def sync(self, localFolder, remoteFolder="", overwrite=False, recursive=True):
+    def sync(
+        self,
+        localFolder,
+        remoteFolder="",
+        overwrite=False,
+        incremental=False,
+        recursive=True,
+    ):
         count = 0
 
         if not os.path.exists(localFolder):
@@ -213,6 +236,9 @@ class RmWebInterfaceAPI:  # TODO: Add docstrings
                 self.logger.debug(f"Processing {doc}")
                 count += 1
                 self.download(
-                    doc, f"{localFolder}/{doc['location']}", overwrite=overwrite
+                    document=doc,
+                    location=f"{localFolder}/{doc['location']}",
+                    overwrite=overwrite,
+                    incremental=incremental,
                 )
             print(f"Done! {count} files were exported.")

--- a/codexctl/sync.py
+++ b/codexctl/sync.py
@@ -1,8 +1,9 @@
-import requests
-import os
 import glob
-
 import logging
+import os
+import time
+
+import requests
 
 
 class RmWebInterfaceAPI:  # TODO: Add docstrings
@@ -154,8 +155,6 @@ class RmWebInterfaceAPI:  # TODO: Add docstrings
             return False
 
     def __is_newer(self, document, fileLocation):
-        import time
-
         remote_ts = document[self.MTIME_ATTRIBUTE]
 
         local_mtime = os.path.getmtime(fileLocation)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ psutil = "6.0.0"
 requests = "2.31.0"
 loguru = "0.7.2"
 remarkable-update-image = { version = "1.1.3", markers = "sys_platform != 'linux'" }
-remarkable-update-fuse = { version = "1.1.2", markers = "sys_platform == 'linux'" }
+remarkable-update-fuse = { version = "1.2.2", markers = "sys_platform == 'linux'" }
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Use `codexctl backup --incremental` to overwrite out-of-date files only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an incremental backup option that allows selective file updating by overwriting only out-of-date files, while keeping the original backup command intact.
- **Documentation**
	- Updated user guidance and examples to explain how to use the new incremental backup feature.
- **Chores**
	- Upgraded a dependency to version 1.2.2 to support the enhanced backup operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->