### PR TITLE
fix: restore_previous_version for rMPP

### DIFF
--- a/codexctl/device.py
+++ b/codexctl/device.py
@@ -389,6 +389,19 @@ echo "fallback: ${OLDPART}"
 /sbin/fw_setenv "fallback_partition" "${OLDPART}"
 /sbin/fw_setenv "active_partition" "${NEWPART}\""""
 
+        if self.hardware == "ferrari":
+            RESTORE_CODE = """#/bin/bash
+OLDPART=$(< /sys/devices/platform/lpgpr/root_part)
+if [[ $OLDPART  ==  "a" ]]; then
+    NEWPART="b"
+else
+    NEWPART="a"
+fi
+echo "new: ${NEWPART}"
+echo "fallback: ${OLDPART}"
+echo $NEWPART > /sys/devices/platform/lpgpr/root_part
+"""
+
         if self.client:
             self.logger.debug("Connecting to FTP")
             ftp = self.client.open_sftp()

--- a/codexctl/device.py
+++ b/codexctl/device.py
@@ -390,7 +390,7 @@ echo "fallback: ${OLDPART}"
 /sbin/fw_setenv "active_partition" "${NEWPART}\""""
 
         if self.hardware == "ferrari":
-            RESTORE_CODE = """#/bin/bash
+            RESTORE_CODE = """#!/bin/bash
 OLDPART=$(< /sys/devices/platform/lpgpr/root_part)
 if [[ $OLDPART  ==  "a" ]]; then
     NEWPART="b"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of device restoration for hardware identified as "ferrari," ensuring correct partition switching during the restore process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->