### PR TITLE
device: add rm1 Prototype

### DIFF
--- a/codexctl/device.py
+++ b/codexctl/device.py
@@ -27,7 +27,7 @@ class HardwareType(enum.Enum):
             return cls.RMPP
         elif device_type.lower() in ("2", "rm2", "remarkable 2", "remarkable 2.0"):
             return cls.RM2
-        elif device_type.lower() in ("1", "rm1", "remarkable 1", "remarkable 1.0"):
+        elif device_type.lower() in ("1", "rm1", "remarkable 1", "remarkable 1.0", "remarkable prototype 1"):
             return cls.RM1
 
         raise ValueError(f"Unknown hardware version: {device_type} (rm1, rm2, rmpp)")


### PR DESCRIPTION
#151 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing "Remarkable Prototype 1" as a valid device type variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->