### PR TITLE
simplify swupdate install to fix partition switching on 3.22+

### DIFF
--- a/codexctl/device.py
+++ b/codexctl/device.py
@@ -737,24 +737,20 @@ fi
 
         else:
             print("Running swupdate")
-            command = f"/usr/sbin/swupdate-from-image-file {version_file}"
+            command = ["/usr/sbin/swupdate-from-image-file", version_file]
             self.logger.debug(command)
 
-            with subprocess.Popen(
-                command,
-                text=True,
-                shell=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                env={"PATH": "/bin:/usr/bin:/sbin:/usr/sbin"},
-            ) as process:
-                if process.wait() != 0:
-                    print("".join(process.stderr.readlines()))
-                    raise SystemError("Update failed")
-
-                self.logger.debug(
-                    f"Stdout of swupdate: {''.join(process.stdout.readlines())}"
+            try:
+                output = subprocess.check_output(
+                    command,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    env={"PATH": "/bin:/usr/bin:/sbin:/usr/sbin"},
                 )
+                self.logger.debug(f"Stdout of swupdate: {output}")
+            except subprocess.CalledProcessError as e:
+                print(e.output)
+                raise SystemError("Update failed")
 
             print("Update complete and device rebooting")
             os.system("reboot")


### PR DESCRIPTION
In testing 3.22+ support, I saw a couple of times when the partition didn't switch after install, but I couldn't reliably replicate it. I believe I've since figured it out: in 3.22+, reMarkable changed how partition switching works:

  1. swupdate sets `/sys/devices/platform/lpgpr/swu_status` to indicate success/failure
  2. On reboot, `rm-apply-ota` checks if swu_status == 1 and calls `rootdev --switch` to change the boot partition
  3. I suspect that if the second swupdate run failed due to it being the current partition, it reset swu_status to 0, causing rm-apply-ota to skip the partition switch

The previous implementation ran swupdate twice (once with -e stable,copy1 and once with -e stable,copy2) to brute-force which partition to install to. One would succeed, one would fail with "over our current root". A code comment calls this a "terrible hack". 

This PR changes to using `/usr/sbin/swupdate-from-image-file` script instead of manually invoking `swupdate`. This script:

  1. Sources `/usr/lib/swupdate/conf.d/09-swupdate-args`
  2. Detects the current partition via `swupdate -g`
  3. Selects the correct copy target automatically
  5. Runs `swupdate` only once

I've verified that both `/usr/sbin/swupdate-from-image-file` and `/usr/lib/swupdate/conf.d/09-swupdate-args` exist in the earliest swu firmware (3.11.3.3) and the latest (3.24.0.149), so this should be a reliable mechanism.

I've successfully tested a `codexctl install` of 3.24.0.149 to both A and B partitions of my rMPP and confirmed the partition switch happened successfully both times. 

In addition to resolving this issue, this change simplifies and cleans up this section of the codebase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable update failure reporting with consistent error messages and exit-status checks.
  * Fixed cases where update commands could leave unclear state; ensured post-update reboot sequence runs consistently.

* **Improvements**
  * Unified remote and local update flows for consistent behavior and faster execution.
  * Added explicit handling for device-specific bootloader downgrades and improved update output logging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->