### PR TITLE
Fix #183

### DIFF
--- a/codexctl/__init__.py
+++ b/codexctl/__init__.py
@@ -352,7 +352,7 @@ class Manager:
                         # `codexctl restore`
 
                 else:
-                    if update_file_requires_new_engine:
+                    if version_number != "3.11.2.5" && update_file_requires_new_engine:
                         raise SystemError(
                             "This version requires the new update engine, please upgrade your device to version 3.11.2.5 first."
                         )

--- a/codexctl/__init__.py
+++ b/codexctl/__init__.py
@@ -352,7 +352,7 @@ class Manager:
                         # `codexctl restore`
 
                 else:
-                    if version_number != "3.11.2.5" && update_file_requires_new_engine:
+                    if version_number != "3.11.2.5" and update_file_requires_new_engine:
                         raise SystemError(
                             "This version requires the new update engine, please upgrade your device to version 3.11.2.5 first."
                         )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined the update installation compatibility check for devices using the legacy update engine. The “new update engine required” block now applies only when the target version is not **3.11.2.5**. This allows installing that specific version on legacy-engine devices while keeping incompatible images blocked for other versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->