### PR TITLE
Only use external provider urls

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -193,47 +193,50 @@ jobs:
           name: remarkable${{ matrix.debug == 1 && '-debug' || '' }}
           path: dist/codexctl
           if-no-files-found: error
-  test_device:
-    name: Test for reMarkable ${{ matrix.fw_version }}
-    needs: [device]
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        fw_version:
-          - "2.15.1.1189"
-          - "3.3.2.1666"
-          # - '3.9.3'
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          path: artifacts
-          name: remarkable
-      - name: Free up space
-        run: |
-          export DEBIAN_FRONTEND="noninteractive"
-          sudo apt-get autoremove -y
-          sudo apt-get autoclean -y
-          sudo rm -rf \
-            /usr/lib/jvm \
-            /usr/share/dotnet \
-            /usr/share/swift \
-            /usr/local/.ghcup \
-            /usr/local/julia* \
-            /usr/local/lib/android \
-            /usr/local/share/chromium \
-            /opt/microsoft /opt/google \
-            /opt/az \
-            /usr/local/share/powershell
-      - uses: Eeems-Org/run-in-remarkable-action@v1
-        with:
-          path: artifacts
-          fw_version: ${{ matrix.fw_version }}
-          run: |
-            chmod +x ./codexctl
-            ./codexctl download --hardware rm2 --out /tmp toltec
+#  test_device:
+#    name: Test for reMarkable ${{ matrix.fw_version }}
+#    needs: [device]
+#    runs-on: ubuntu-latest
+#    strategy:
+#      matrix:
+#        fw_version:
+#          - "2.15.1.1189"
+#          - "3.3.2.1666"
+#          # - '3.9.3'
+#    steps:
+#      - uses: actions/download-artifact@v4
+#        with:
+#          path: artifacts
+#          name: remarkable
+#      - name: Free up space
+#        run: |
+#          export DEBIAN_FRONTEND="noninteractive"
+#          sudo apt-get autoremove -y
+#          sudo apt-get autoclean -y
+#          sudo rm -rf \
+#            /usr/lib/jvm \
+#            /usr/share/dotnet \
+#            /usr/share/swift \
+#            /usr/local/.ghcup \
+#            /usr/local/julia* \
+#            /usr/local/lib/android \
+#            /usr/local/share/chromium \
+#            /opt/microsoft /opt/google \
+#            /opt/az \
+#            /usr/local/share/powershell
+#      - uses: Eeems-Org/run-in-remarkable-action@v1
+#        with:
+#          path: artifacts
+#          fw_version: ${{ matrix.fw_version }}
+#          run: |
+#            chmod +x ./codexctl
+#            ./codexctl download --hardware rm2 --out /tmp toltec
   release:
     name: Release
-    needs: [remote, device, test_device]
+    needs:
+      - remote
+      - device
+      #- test_device
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     permissions:

--- a/Makefile
+++ b/Makefile
@@ -58,13 +58,13 @@ $(VENV_BIN_ACTIVATE): requirements.remote.txt requirements.txt
 	@echo "[info] Downloading remarkable update file"
 	@set -e; \
 	. $(VENV_BIN_ACTIVATE); \
-	python -m codexctl download --hardware rm2 --out .venv ${FW_VERSION}
+	python -m codexctl --verbose download --hardware rm2 --out .venv ${FW_VERSION}
 
 .venv/$(FW_FILE_SWU): $(VENV_BIN_ACTIVATE) $(OBJ)
 	@echo "[info] Downloading remarkable .swu update file"
 	@set -e; \
 	. $(VENV_BIN_ACTIVATE); \
-	python -m codexctl download --hardware rm2 --out .venv $(FW_VERSION_SWU)
+	python -m codexctl --verbose download --hardware rm2 --out .venv $(FW_VERSION_SWU)
 
 test: $(VENV_BIN_ACTIVATE) .venv/${FW_VERSION}_reMarkable2-${FW_DATA}.signed .venv/$(FW_FILE_SWU)
 	@echo "[info] Running test"

--- a/codexctl/updates.py
+++ b/codexctl/updates.py
@@ -221,9 +221,6 @@ class UpdateManager:
             )
             os.makedirs(download_folder)
 
-        BASE_URL = "https://updates-download.cloud.remarkable.engineering/build/reMarkable%20Device%20Beta/RM110"  # Default URL for v2 versions
-        BASE_URL_V3 = "https://updates-download.cloud.remarkable.engineering/build/reMarkable%20Device/reMarkable"
-
         match hardware_type:
             case HardwareType.RMPPURE:
                 version_lookup = self.remarkableppure_versions
@@ -249,7 +246,7 @@ class UpdateManager:
 
         version_id, version_checksum = version_lookup[update_version]
         version = tuple([int(x) for x in update_version.split(".")])
-        if version >= (3,):
+        if version version <= (3, 11, 2, 5):
             file_name = (
                 f"{update_version}_{hardware_type.old_download_hw}-{version_id}.signed"
             )

--- a/codexctl/updates.py
+++ b/codexctl/updates.py
@@ -248,41 +248,26 @@ class UpdateManager:
             return
 
         version_id, version_checksum = version_lookup[update_version]
-        version = tuple([int(x) for x in update_version.split(".")])
-        if version >= (3,):
-            BASE_URL = BASE_URL_V3
+        file_name = f"remarkable-production-memfault-image-{update_version}-{hardware_type.new_download_hw}-public"
 
-        if version <= (3, 11, 2, 5):
-            file_name = (
-                f"{update_version}_{hardware_type.old_download_hw}-{version_id}.signed"
-            )
-            file_url = f"{BASE_URL}/{update_version}/{file_name}"
-            self.logger.debug(f"File URL is {file_url}, File name is {file_name}")
-            return self.__download_version_file(
+        for provider_url in self.external_provider_urls:
+            file_url = provider_url.replace("REPLACE_ID", version_id)
+            self.logger.debug(f"Trying to download from {file_url}")
+
+            result = self.__download_version_file(
                 file_url, file_name, download_folder, version_checksum
             )
 
-        else:
-            file_name = f"remarkable-production-memfault-image-{update_version}-{hardware_type.new_download_hw}-public"
+            if result is not None:
+                self.logger.debug(f"Successfully downloaded from {provider_url}")
+                return result
 
-            for provider_url in self.external_provider_urls:
-                file_url = provider_url.replace("REPLACE_ID", version_id)
-                self.logger.debug(f"Trying to download from {file_url}")
+            self.logger.debug(
+                f"Failed to download from {provider_url}, trying next source..."
+            )
 
-                result = self.__download_version_file(
-                    file_url, file_name, download_folder, version_checksum
-                )
-
-                if result is not None:
-                    self.logger.debug(f"Successfully downloaded from {provider_url}")
-                    return result
-
-                self.logger.debug(
-                    f"Failed to download from {provider_url}, trying next source..."
-                )
-
-            self.logger.error(f"Failed to download {file_name} from all sources")
-            return None
+        self.logger.error(f"Failed to download {file_name} from all sources")
+        return None
 
     def __generate_xml_data(self) -> str:
         """Generates and returns XML data for the update request"""

--- a/codexctl/updates.py
+++ b/codexctl/updates.py
@@ -248,7 +248,14 @@ class UpdateManager:
             return
 
         version_id, version_checksum = version_lookup[update_version]
-        file_name = f"remarkable-production-memfault-image-{update_version}-{hardware_type.new_download_hw}-public"
+        version = tuple([int(x) for x in update_version.split(".")])
+        if version >= (3,):
+            file_name = (
+                f"{update_version}_{hardware_type.old_download_hw}-{version_id}.signed"
+            )
+
+        else:
+            file_name = f"remarkable-production-memfault-image-{update_version}-{hardware_type.new_download_hw}-public"
 
         for provider_url in self.external_provider_urls:
             file_url = provider_url.replace("REPLACE_ID", version_id)

--- a/codexctl/updates.py
+++ b/codexctl/updates.py
@@ -246,7 +246,7 @@ class UpdateManager:
 
         version_id, version_checksum = version_lookup[update_version]
         version = tuple([int(x) for x in update_version.split(".")])
-        if version version <= (3, 11, 2, 5):
+        if version <= (3, 11, 2, 5):
             file_name = (
                 f"{update_version}_{hardware_type.old_download_hw}-{version_id}.signed"
             )

--- a/codexctl/updates.py
+++ b/codexctl/updates.py
@@ -233,7 +233,6 @@ class UpdateManager:
 
             case HardwareType.RM2:
                 version_lookup = self.remarkable2_versions
-                BASE_URL_V3 += "2"
 
             case HardwareType.RM1:
                 version_lookup = self.remarkable1_versions

--- a/codexctl/updates.py
+++ b/codexctl/updates.py
@@ -254,7 +254,7 @@ class UpdateManager:
             file_name = f"remarkable-production-memfault-image-{update_version}-{hardware_type.new_download_hw}-public"
 
         for provider_url in self.external_provider_urls:
-            file_url = provider_url.replace("REPLACE_ID", version_id)
+            file_url = provider_url.replace("REPLACE_ID", version_id).replace("REPLACE_NAME", file_name)
             self.logger.debug(f"Trying to download from {file_url}")
 
             result = self.__download_version_file(

--- a/data/version-ids.json
+++ b/data/version-ids.json
@@ -565,7 +565,7 @@
     "external-provider-urls": [
         "https://storage.googleapis.com/remarkable-versions/REPLACE_ID",
         "https://remarkable-software.s3.us-east-2.amazonaws.com/REPLACE_ID",
-        "https://remarkable-software.s3.us-east-2.amazonaws.com/omaha/rm1/REPLACE_ID",
-        "https://remarkable-software.s3.us-east-2.amazonaws.com/omaha/rm2/REPLACE_ID"
+        "https://remarkable-software.s3.us-east-2.amazonaws.com/omaha/rm1/REPLACE_NAME",
+        "https://remarkable-software.s3.us-east-2.amazonaws.com/omaha/rm2/REPLACE_NAME"
     ]
 }

--- a/data/version-ids.json
+++ b/data/version-ids.json
@@ -564,6 +564,8 @@
     "last-updated": 1778173895,
     "external-provider-urls": [
         "https://storage.googleapis.com/remarkable-versions/REPLACE_ID",
-        "https://remarkable-software.s3.us-east-2.amazonaws.com/REPLACE_ID"
+        "https://remarkable-software.s3.us-east-2.amazonaws.com/REPLACE_ID",
+        "https://remarkable-software.s3.us-east-2.amazonaws.com/omaha/rm1/REPLACE_ID",
+        "https://remarkable-software.s3.us-east-2.amazonaws.com/omaha/rm2/REPLACE_ID"
     ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Download system now supports multiple external provider sources with automatic fallback to improve reliability across versions.
  * Expanded provider URL configuration to cover additional Omaha download locations for rm1 and rm2.
* **Build & CI**
  * Updated development download commands to enable verbose output for easier troubleshooting.
  * Disabled the device testing step in the main workflow, so the release pipeline no longer waits for device testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->